### PR TITLE
Update setup-dev paths and docs

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -114,7 +114,7 @@ The `config/docker-compose.yml` includes:
 ### 1. Backend Deployment
 
 ```bash
-cd current/backend
+cd backend
 
 # Install dependencies
 pip install -r ../config/requirements.txt
@@ -129,7 +129,7 @@ python main.py
 ### 2. Frontend Deployment
 
 ```bash
-cd current/frontend
+cd frontend
 
 # Install dependencies
 npm install
@@ -150,10 +150,10 @@ Use PM2 for production process management:
 npm install -g pm2
 
 # Start backend
-pm2 start current/backend/main.py --name swarm-backend --interpreter python3
+pm2 start backend/main.py --name swarm-backend --interpreter python3
 
 # Start frontend (if serving with Node.js)
-pm2 start "npm run preview" --name swarm-frontend --cwd current/frontend
+pm2 start "npm run preview" --name swarm-frontend --cwd frontend
 
 # Save PM2 configuration
 pm2 save
@@ -166,21 +166,21 @@ pm2 startup
 
 1. **Backend Deployment**:
    - Connect your GitHub repository
-   - Set build command: `pip install -r current/config/requirements.txt`
-   - Set start command: `cd current/backend && python main.py`
+   - Set build command: `pip install -r config/requirements.txt`
+   - Set start command: `cd backend && python main.py`
    - Add environment variables from `.env`
 
 2. **Frontend Deployment**:
    - Create new static site
-   - Set build command: `cd current/frontend && npm install && npm run build`
-   - Set publish directory: `current/frontend/dist`
+   - Set build command: `cd frontend && npm install && npm run build`
+   - Set publish directory: `frontend/dist`
 
 ### Heroku Deployment
 
 1. **Prepare Heroku files**:
 ```bash
 # Create Procfile in root
-echo "web: cd current/backend && python main.py" > Procfile
+echo "web: cd backend && python main.py" > Procfile
 
 # Create runtime.txt
 echo "python-3.11.0" > runtime.txt
@@ -294,8 +294,8 @@ curl http://localhost:5000/api/system/status | jq '.data.services'
 git pull origin main
 
 # Update dependencies
-cd current/backend && pip install -r ../config/requirements.txt
-cd current/frontend && npm install
+cd backend && pip install -r ../config/requirements.txt
+cd frontend && npm install
 
 # Restart services
 docker-compose -f config/docker-compose.yml restart
@@ -308,7 +308,7 @@ docker-compose -f config/docker-compose.yml restart
 pg_dump $DATABASE_URL > backup.sql
 
 # Run any new migrations
-python current/backend/main.py --migrate
+python backend/main.py --migrate
 ```
 
 ### Monitoring and Alerts

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -37,11 +37,11 @@ cp .env.example .env
 ### 3. Development Environment
 ```bash
 # Terminal 1: Backend
-cd current/backend
+cd backend
 python main.py
 
 # Terminal 2: Frontend
-cd current/frontend
+cd frontend
 npm run dev
 
 # Terminal 3: Redis (optional)
@@ -53,7 +53,7 @@ redis-server
 ### Backend Architecture
 
 ```
-current/backend/
+backend/
 ├── main.py                 # Application entry point
 ├── swarm_orchestrator.py   # Enhanced orchestrator with Communication Agent
 ├── services/               # Service layer
@@ -219,7 +219,7 @@ result = await cache.get("key")
 ### Component Structure
 
 ```
-current/frontend/src/
+frontend/src/
 ├── components/
 │   ├── ui/                 # Reusable UI components
 │   └── EnhancedComponents.jsx  # Agent-specific components
@@ -295,7 +295,7 @@ import { NewFeature } from './components/NewFeature';
 pip install pytest pytest-asyncio
 
 # Run tests
-cd current/backend
+cd backend
 python -m pytest tests/ -v
 
 # Test specific service
@@ -318,7 +318,7 @@ async def test_postgresql_connection():
 ### Frontend Testing
 
 ```bash
-cd current/frontend
+cd frontend
 npm test
 ```
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -9,7 +9,7 @@ echo "🤖 Setting up Swarm Multi-Agent System v3.0 Development Environment"
 echo "=================================================================="
 
 # Check if we're in the right directory
-if [ ! -f "README.md" ] || [ ! -d "current" ]; then
+if [ ! -f "README.md" ] || [ ! -d "backend" ] || [ ! -d "frontend" ]; then
     echo "❌ Error: Please run this script from the swarm-platform-v3 root directory"
     exit 1
 fi
@@ -47,7 +47,7 @@ echo "✅ npm $NPM_VERSION found"
 # Setup backend
 echo ""
 echo "🐍 Setting up Python backend..."
-cd current/backend
+cd backend
 
 # Create virtual environment if it doesn't exist
 if [ ! -d "venv" ]; then
@@ -137,12 +137,12 @@ echo "   - Add your SUPERMEMORY_API_KEY and SUPERMEMORY_BASE_URL"
 echo ""
 echo "2. Start the development servers:"
 echo "   Terminal 1 (Backend):"
-echo "   cd current/backend"
+echo "   cd backend"
 echo "   source venv/bin/activate"
 echo "   python main.py"
 echo ""
 echo "   Terminal 2 (Frontend):"
-echo "   cd current/frontend"
+echo "   cd frontend"
 echo "   npm run dev"
 echo ""
 echo "3. Access the application:"
@@ -151,8 +151,8 @@ echo "   - Frontend: http://localhost:5173"
 echo "   - Health Check: http://localhost:5000/api/health"
 echo ""
 echo "📚 Documentation:"
-echo "   - Development Guide: current/docs/DEVELOPMENT_GUIDE.md"
-echo "   - Deployment Guide: current/docs/DEPLOYMENT_GUIDE.md"
+echo "   - Development Guide: docs/DEVELOPMENT_GUIDE.md"
+echo "   - Deployment Guide: docs/DEPLOYMENT_GUIDE.md"
 echo ""
 echo "🤖 Happy coding with Swarm Multi-Agent System v3.0!"
 


### PR DESCRIPTION
## Summary
- update setup-dev script paths from `current` folder
- reference backend and frontend directly in docs

## Testing
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `bash scripts/setup-dev.sh` *(fails to install npm packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6859aecd25948321ad7d4a0c1f3fc1d9