### PR TITLE
Add email notification hooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ SUPERMEMORY_BASE_URL=https://your-supermemory-instance.com
 # Email Service
 MAILGUN_API_KEY=your_mailgun_api_key_here
 MAILGUN_DOMAIN=your-domain.com
+NOTIFICATION_EMAIL=your-email@example.com
 
 # Application Settings
 DEBUG=false

--- a/RENDER_ENV_VARS.md
+++ b/RENDER_ENV_VARS.md
@@ -27,6 +27,7 @@ SUPERMEMORY_BASE_URL=https://api.supermemory.ai
 MAILGUN_API_KEY=your-mailgun-api-key
 MAILGUN_DOMAIN=your-mailgun-domain.com
 MAILGUN_WEBHOOK_SIGNING_KEY=your-mailgun-webhook-signing-key
+NOTIFICATION_EMAIL=your-email@example.com
 ```
 
 ### File System (Optional - has defaults)

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,6 +76,7 @@ class SwarmApplication:
             'MAILGUN_API_KEY': os.getenv('MAILGUN_API_KEY'),
             'MAILGUN_DOMAIN': os.getenv('MAILGUN_DOMAIN'),
             'MAILGUN_WEBHOOK_SIGNING_KEY': os.getenv('MAILGUN_WEBHOOK_SIGNING_KEY'),
+            'NOTIFICATION_EMAIL': os.getenv('NOTIFICATION_EMAIL'),
             
             # MCP Filesystem configuration
             'MCP_WORKSPACE_PATH': os.getenv('MCP_WORKSPACE_PATH', '/tmp/swarm_workspace'),
@@ -272,8 +273,15 @@ class SwarmApplication:
             'SUPERMEMORY_API_KEY',
             'SUPERMEMORY_BASE_URL'
         ]
-        
-        return [config for config in required_configs if not self.config.get(config)]
+
+        optional_configs = ['MAILGUN_API_KEY', 'MAILGUN_DOMAIN']
+
+        missing_required = [c for c in required_configs if not self.config.get(c)]
+        missing_optional = [c for c in optional_configs if not self.config.get(c)]
+        if missing_optional:
+            logger.warning(f"⚠️ Optional configs missing: {missing_optional}")
+
+        return missing_required
     
     async def initialize_services(self):
         """Initialize all services asynchronously"""
@@ -324,18 +332,20 @@ class SwarmApplication:
             else:
                 logger.warning("⚠️ Mailgun not configured")
             
+            # Initialize Swarm Orchestrator
+            self.orchestrator = SwarmOrchestrator()
+            logger.info("✅ Swarm Orchestrator initialized")
+
             # Initialize WebSocket service
-            websocket_service = initialize_websocket_service(self.app, mcp_service)
+            websocket_service = initialize_websocket_service(
+                self.app, mcp_service, self.orchestrator
+            )
             service_registry.register(websocket_service)
-            
+
             # Register WebSocket namespace
             swarm_namespace = SwarmNamespace('/swarm', websocket_service)
             self.socketio.on_namespace(swarm_namespace)
             logger.info("✅ WebSocket service initialized")
-            
-            # Initialize Swarm Orchestrator
-            self.orchestrator = SwarmOrchestrator()
-            logger.info("✅ Swarm Orchestrator initialized")
             
             self._services_initialized = True
             logger.info("🎉 All services initialized successfully!")

--- a/backend/test_backend.py
+++ b/backend/test_backend.py
@@ -246,6 +246,23 @@ async def test_application_creation():
         logger.error(f"❌ Application creation test failed: {e}")
         return False
 
+def test_optional_mailgun_config():
+    """Ensure missing Mailgun config does not count as required"""
+    try:
+        import sqlalchemy  # noqa: F401
+    except ImportError:
+        logger.warning("sqlalchemy not installed; skipping test")
+        return True
+
+    from backend.main import SwarmApplication
+
+    os.environ.pop('MAILGUN_API_KEY', None)
+    os.environ.pop('MAILGUN_DOMAIN', None)
+
+    app_instance = SwarmApplication()
+    missing = app_instance._get_missing_configs()
+    return 'MAILGUN_API_KEY' not in missing and 'MAILGUN_DOMAIN' not in missing
+
 async def run_all_tests():
     """Run all backend tests"""
     logger.info("🚀 Starting Backend Service Tests")
@@ -263,6 +280,7 @@ async def run_all_tests():
     test_results.append(("Async Utilities", await test_async_utilities()))
     test_results.append(("MCP Filesystem", await test_mcp_filesystem()))
     test_results.append(("Application Creation", await test_application_creation()))
+    test_results.append(("Optional Mailgun Config", test_optional_mailgun_config()))
     
     # Print results
     logger.info("\n" + "=" * 50)

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -44,6 +44,7 @@ SUPERMEMORY_BASE_URL=https://your-supermemory-instance.com
 MAILGUN_API_KEY=your-mailgun-api-key
 MAILGUN_DOMAIN=your-domain.com
 MAILGUN_WEBHOOK_SIGNING_KEY=your-webhook-signing-key
+NOTIFICATION_EMAIL=your-email@example.com
 
 # Server Configuration
 HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- trigger SwarmOrchestrator email after conversations
- warn when Mailgun env vars are missing
- allow configuring notification email via env
- document new `NOTIFICATION_EMAIL` variable
- add test for optional Mailgun config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8 backend/main.py backend/services/websocket_service.py backend/test_backend.py` *(fails: E501 line too long, F401 unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_6859aee488d08321b417be67600b962a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional notification email address via the `NOTIFICATION_EMAIL` environment variable. If set, the system can send notification emails after certain events.
- **Documentation**
  - Updated environment variable documentation and deployment guide to include the new `NOTIFICATION_EMAIL` option.
- **Bug Fixes**
  - Improved configuration handling to treat Mailgun-related email settings as optional, with appropriate warnings if missing.
- **Tests**
  - Added a test to verify that Mailgun email configuration variables are treated as optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->