### PR TITLE
Fix: Update requirements.txt path in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,7 @@ services:
     buildCommand: |
       echo "🔧 Starting build process..."
       pip install --upgrade pip
-      pip install -r requirements.txt
+      pip install -r config/requirements.txt
       echo "📦 Verifying critical packages..."
       pip list | grep -E "(flask|gunicorn|psycopg2|requests|pydantic)"
       echo "✅ Build completed successfully!"


### PR DESCRIPTION
## Summary
This PR fixes the deployment failure on Render by correcting the path to requirements.txt.

## Problem
The deployment was failing with:
```
ModuleNotFoundError: No module named 'flask_migrate'
```

## Root Cause
The `render.yaml` was looking for `requirements.txt` in the root directory, but the file is actually located in `config/requirements.txt`.

## Solution
Updated the build command in `render.yaml` from:
```bash
pip install -r requirements.txt
```
to:
```bash
pip install -r config/requirements.txt
```

## Testing
After this change is merged, Render should:
1. Find and install all dependencies from `config/requirements.txt`
2. Successfully import `flask-migrate` and other required packages
3. Complete the deployment without errors

## Deployment Note
This change will trigger an automatic redeployment on Render once merged.