### PR TITLE
Fix frontend production API connection

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🤖</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>🤖 Swarm Multi-Agent System</title>
     <meta name="description" content="Sophisticated multi-agent AI system with real-time collaboration and swarm intelligence" />
@@ -11,8 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
-    <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Tailwind CSS is bundled via Vite plugin -->
     
     <!-- Custom CSS for animations and themes -->
     <style>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,21 @@ import {
   ChevronDown, Sun, Send
 } from 'lucide-react';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+// Dynamically determine API URL based on current location
+const API_BASE_URL = (() => {
+  // If VITE_API_URL is set, use it
+  if (import.meta.env.VITE_API_URL) {
+    return import.meta.env.VITE_API_URL;
+  }
+  
+  // In production, use the same origin as the frontend
+  if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
+    return window.location.origin;
+  }
+  
+  // In development, use localhost:5000
+  return 'http://localhost:5000';
+})();
 
 function App() {
   // Core State

--- a/frontend/src/components/EnhancedComponents.jsx
+++ b/frontend/src/components/EnhancedComponents.jsx
@@ -551,7 +551,19 @@ const useWebSocket = (onMessage, onHistory, onStatus) => {
   const socketRef = useRef(null);
 
   useEffect(() => {
-    const base = import.meta.env.VITE_WS_URL || import.meta.env.VITE_API_URL || 'http://localhost:5000';
+    // Dynamically determine WebSocket URL
+    const base = (() => {
+      if (import.meta.env.VITE_WS_URL) return import.meta.env.VITE_WS_URL;
+      if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
+      
+      // In production, use the same origin as the frontend
+      if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
+        return window.location.origin;
+      }
+      
+      // In development, use localhost:5000
+      return 'http://localhost:5000';
+    })();
     socketRef.current = io(base + '/swarm', {
       transports: ['websocket', 'polling']
     });


### PR DESCRIPTION
## Summary
This PR fixes the frontend connection issues in production.

## Problems Fixed

1. **API Connection Error**
   - Frontend was trying to connect to `localhost:5000` instead of the deployed URL
   - Now dynamically uses `window.location.origin` in production

2. **WebSocket Connection**
   - Same issue with WebSocket connections
   - Now uses same dynamic URL logic

3. **Missing vite.svg**
   - Replaced with emoji favicon to fix 404 error

4. **Tailwind CDN Warning**
   - Removed CDN script tag (Tailwind is bundled via Vite plugin)

## How It Works
The frontend now detects if it's running in production (not localhost) and automatically uses the same domain for API calls. This means:
- On localhost: Uses `http://localhost:5000`
- On Render: Uses `https://your-app.onrender.com`
- No configuration needed\!

## Testing
After deployment:
1. Frontend should load without connection errors
2. API calls should work (`/api/agents` etc)
3. No more favicon 404
4. No more Tailwind CDN warning